### PR TITLE
Alpha/nested delete/bug

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -174,7 +174,7 @@ dependencies = [
  "js-sys 0.3.37 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "maplit 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "node-sys 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "node-sys 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pest 2.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "pest_derive 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -244,18 +244,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "node-sys"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "js-sys 0.3.37 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
- "web-sys 0.3.37 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "node-sys"
-version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -737,7 +725,6 @@ dependencies = [
 "checksum maplit 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 "checksum memory_units 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8452105ba047068f40ff7093dd1d9da90898e63dd61736462e9cdda6a90ad3c3"
 "checksum node-sys 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "01c5f73f02a7e6bdeb5d85cb42327649f05c56e19b479398702218f23ece7232"
-"checksum node-sys 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "30d75eee6e8b159228449706773f9f2af60720250308124e9c3d38bd8070844a"
 "checksum num-traits 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "c62be47e61d1842b9170f0fdeec8eba98e60e90e5446449a0545e5152acd7096"
 "checksum opaque-debug 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
 "checksum pest 2.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "10f4872ae94d7b90ae48754df22fd42ad52ce740b8f370b03da4835417403e53"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ itertools = "0.8.2"
 pest = "2.1.2"
 pest_derive = "2.1.0"
 js-sys = "0.3.35"
-node-sys = "0.4.0"
+node-sys = "0.3.0"
 electron-sys = "0.4.0"
 
 # The `console_error_panic_hook` crate provides better debugging of panics by

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/main.js",
   "scripts": {
     "dev": "watch 'npm run start' src",
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "cargo test",
     "start-cargo": "cargo watch -w src/ -s './scripts/build.sh && electron .'",
     "start": "webpack --config ./webpack.config.js && electron dist/main.js",
     "watch": "cargo watch -w src/ -w static/styles.css -s 'npm run start'",

--- a/src/model.rs
+++ b/src/model.rs
@@ -713,21 +713,21 @@ impl Component for Model {
                 true
             }
             Action::SaveSession() => {
-                /* TODO: uncomment when this is working
+                // TODO: uncomment when this is working
                 use node_sys::fs as node_fs;
                 use node_sys::Buffer;
                 use js_sys::{
                     JsString,
                     Function
                 };
-                let session = self.to_session();
-                let j = serde_json::to_string(&session.clone());
-                let filename = session.title.to_string();
+                let current_session = self.to_session();
+                let j = serde_json::to_string(&current_session.clone());
+                let filename = current_session.title.to_string();
                 let jsfilename = JsString::from(filename);
                 let jsbuffer = Buffer::from_string(&JsString::from(j.unwrap()), None);
                 let jscallback = Function::new_no_args("{}");
                 node_fs::append_file(&jsfilename, &jsbuffer, None, &jscallback);
-                */
+                
                 false
             }
 

--- a/src/model.rs
+++ b/src/model.rs
@@ -283,6 +283,44 @@ impl Model {
             })
             .collect()
     }
+    fn Reassign(&mut self, Coord: Coordinate, mut grammars: HashMap<Coordinate, Grammar>, i: i32) -> HashMap<Coordinate, Grammar> {
+
+        // let mut grammars = self.get_session_mut().grammars.clone();
+        let mut new_parent: Coordinate;
+        if let Some(Grammar {
+            kind: Kind::Grid(sub_coords),
+            name: _,
+            style: _,
+        }) = &mut grammars.get(&Coord.clone())
+        {   
+            match i{
+                0 => {new_parent = Coordinate::child_of(&Coord.parent().unwrap(), (NonZeroU32::new(Coord.row().get() - 1).unwrap(), Coord.col()))}
+                _ => {new_parent = Coordinate::child_of(&Coord.parent().unwrap(), (Coord.row(), (NonZeroU32::new(Coord.col().get() - 1).unwrap())))}
+            }
+            // take old parent coord to copy its grammar into the new_parent coordinate for each sub_coordinates
+            let mut grammar_copy = grammars.clone();
+            for child_ in sub_coords {
+                
+                let old_coord = Coordinate::child_of(&Coord, *child_);
+                info!("Old {:?}", old_coord);
+                let new_coord = Coordinate::child_of(&new_parent, *child_);
+                info!("New {:?}", new_coord);
+                grammar_copy.insert(new_coord.clone(), grammar_copy.get(&old_coord.clone()).clone().unwrap().clone());
+                grammar_copy.remove(&old_coord);
+                if let Some(Grammar {
+                    kind: Kind::Grid(sub_coords_temp),
+                    name: _,
+                    style: _,
+                }) = &mut grammars.get(&old_coord.clone())
+                { 
+                    grammar_copy = self.Reassign(old_coord.clone(), grammar_copy.clone(), i);
+                }
+            }
+            grammars = grammar_copy;
+        }
+        
+        grammars
+    }
 }
 
 impl Component for Model {
@@ -357,16 +395,7 @@ impl Component for Model {
                             [
                                 g!(Grammar::input("", "A3")),
                                 g!(Grammar::input("", "B3")),
-                                grid![
-                                    [
-                                        g!(Grammar::input("", "C3-A1")),
-                                        g!(Grammar::input("", "C3-B1"))
-                                    ],
-                                    [
-                                        g!(Grammar::input("", "C3-A2")),
-                                        g!(Grammar::input("", "C3-B2"))
-                                    ]
-                                ]
+                                g!(Grammar::input("", "C3"))
                             ]
                         ],
                     );
@@ -414,7 +443,6 @@ impl Component for Model {
                         ],
                     );
                     assert!(map.contains_key(&(coord!("root"))));
-                    assert!(map.contains_key(&(coord!("root-C3-B2"))));
                     map
                 },
             }],
@@ -700,15 +728,19 @@ impl Component for Model {
             }
 
             Action::ReadSession(file) => {
-                let callback = self.link.callback(Action::LoadSession);
-                let task = self.reader.read_file(file, callback);
-                self.tasks.push(task);
+                info!("in here");
+                
+                self.tasks.push(self.reader.read_file(file, 
+                    self.link.callback(Action::LoadSession)));
+                info!("task");
                 false
             }
 
             Action::LoadSession(file_data) => {
+                info!("file data: {:?}", file_data);
                 let session: Session =
-                    serde_json::from_str(format! {"{:?}", file_data}.deref()).unwrap();
+                    serde_json::from_str(format! {"{:?}", file_data.content}.deref()).unwrap();
+                info!(" LOADSESSION");
                 self.load_session(session);
                 true
             }
@@ -722,7 +754,7 @@ impl Component for Model {
                 };
                 let current_session = self.to_session();
                 let j = serde_json::to_string(&current_session.clone());
-                let filename = current_session.title.to_string();
+                let filename = current_session.title.to_string() + ".json";
                 let jsfilename = JsString::from(filename);
                 let jsbuffer = Buffer::from_string(&JsString::from(j.unwrap()), None);
                 let jscallback = Function::new_no_args("{}");
@@ -952,16 +984,11 @@ impl Component for Model {
                     // info!("current_width-{}, current_height-{}", current_width.clone(), current_height.clone());
                 }
 
-                if let Some(parent) = Coordinate::parent(&coord)
-                    .and_then(|p| self.get_session_mut().grammars.get_mut(&p))
-                {
-                    parent.kind = grammar.clone().kind; // make sure the parent gets set to Kind::Grid
-                }
-
                 if current_grammar.style.row_span.0 != 0 || current_grammar.style.col_span.0 != 0 {
                     grammar.style.row_span = current_grammar.style.row_span.clone();
                     grammar.style.col_span = current_grammar.style.col_span.clone();
                 }
+                info!("grammar {:?}", grammar);
                 self.get_session_mut()
                     .grammars
                     .insert(coord.clone(), grammar.clone());
@@ -1086,12 +1113,12 @@ impl Component for Model {
                     //Have to initialize many things for them to work in loop
                     let mut next_row = coord.clone();
                     let mut grammars = self.get_session_mut().grammars.clone();
-                    let mut row_coords1 = self.query_row(next_row.full_row());
+                    let mut cur_row_coord = self.query_row(next_row.full_row());
                     let _parent = coord.parent().unwrap();
 
                     let mut temp: Vec<Grammar> = vec![];
                     let mut u = 0;
-                    let mut row_coords2 = self.query_row(next_row.full_row());
+                    let mut next_row_coord = self.query_row(next_row.full_row());
                     let mut new_row_coords: std::vec::Vec<(
                         std::num::NonZeroU32,
                         std::num::NonZeroU32,
@@ -1100,22 +1127,30 @@ impl Component for Model {
                     //Changing each rowfrom the one being deleted
                     while let Some(below_coord) = next_row.neighbor_below() {
                         temp.clear();
-                        row_coords2 = self.query_row(below_coord.full_row());
-                        if row_coords2.len() != 0 {
+                        next_row_coord = self.query_row(below_coord.full_row());
+                        if next_row_coord.len() != 0 {
                             temp = std::vec::from_elem(
-                                grammars[&row_coords2[0]].clone(),
-                                row_coords2.len(),
+                                grammars[&next_row_coord[0]].clone(),
+                                next_row_coord.len(),
                             );
 
-                            //each grammar copied
-                            for i in row_coords2.clone() {
+                            // each grammar copied
+                            for i in next_row_coord.clone() {
                                 u = i.col().get() as usize;
                                 temp.insert(u, grammars[&i].clone());
                             }
                             u = 0;
                         }
-
-                        if temp.len() == 0 {
+                        // checking if last row
+                        if temp.len() != 0 {
+                            // for loop for reassignment
+                            for c in (0..cur_row_coord.len()).rev() {
+                                grammars = self.Reassign(cur_row_coord[c].clone(), grammars.clone(), 0);
+                                grammars.insert(cur_row_coord[c].clone(), temp[u].clone());                                
+                                u += 1;
+                            }
+                            u = 0;       
+                        } else {
                             let parent = next_row.parent().unwrap();
                             if let Some(Grammar {
                                 kind: Kind::Grid(sub_coords),
@@ -1125,7 +1160,7 @@ impl Component for Model {
                             {
                                 new_row_coords = sub_coords.clone();
 
-                                for c in row_coords1.clone() {
+                                for c in cur_row_coord.clone() {
                                     for i in (0..new_row_coords.len()).rev() {
                                         if new_row_coords[i] == (c.row(), c.col()) {
                                             new_row_coords.remove(i);
@@ -1138,6 +1173,9 @@ impl Component for Model {
                                 }
                                 grammars.remove(&parent);
                                 grammars.remove(&next_row);
+                                for i in next_row_coord.clone() {
+                                    grammars.remove(&i);
+                                }
                                 grammars.insert(
                                     parent,
                                     Grammar {
@@ -1148,17 +1186,9 @@ impl Component for Model {
                                 );
                                 break;
                             }
-                        } else {
-                            // info!("XD {:?}", row_coords1);
-                            // info!("Temp {:?}", temp);
-                            for c in (0..row_coords1.len()).rev() {
-                                grammars.insert(row_coords1[c].clone(), temp[u].clone());
-                                u += 1;
-                            }
-                            u = 0;
                         }
 
-                        row_coords1 = row_coords2.clone();
+                        cur_row_coord = next_row_coord.clone();
                         next_row = below_coord;
                     }
                     self.get_session_mut().grammars = grammars;
@@ -1171,12 +1201,12 @@ impl Component for Model {
                     //Have to initialize many things for them to work in loop
                     let mut next_col = coord.clone();
                     let mut grammars = self.get_session_mut().grammars.clone();
-                    let mut col_coords1 = self.query_col(next_col.full_col());
+                    let mut cur_col_coord = self.query_col(next_col.full_col());
                     let parent = coord.parent().unwrap();
 
                     let mut temp: Vec<Grammar> = vec![];
                     let mut u = 0;
-                    let mut col_coords2 = self.query_col(next_col.full_col());
+                    let mut next_col_coord = self.query_col(next_col.full_col());
                     let mut new_col_coords: std::vec::Vec<(
                         std::num::NonZeroU32,
                         std::num::NonZeroU32,
@@ -1193,22 +1223,29 @@ impl Component for Model {
                     //Changing each colfrom the one being deleted
                     while let Some(right_coord) = next_col.neighbor_right() {
                         temp.clear();
-                        col_coords2 = self.query_col(right_coord.full_col());
-                        if col_coords2.len() != 0 {
+                        next_col_coord = self.query_col(right_coord.full_col());
+                        if next_col_coord.len() != 0 {
                             temp = std::vec::from_elem(
-                                grammars[&col_coords2[0]].clone(),
-                                col_coords2.len(),
+                                grammars[&next_col_coord[0]].clone(),
+                                next_col_coord.len(),
                             );
 
                             //each grammar copied
-                            for i in col_coords2.clone() {
+                            for i in next_col_coord.clone() {
                                 u = i.col().get() as usize;
                                 temp.insert(u, grammars[&i].clone());
                             }
 
                             u = 0;
                         }
-                        if temp.len() == 0 {
+                        if temp.len() != 0 {
+                                for c in (0..cur_col_coord.len()).rev() {
+                                    grammars = self.Reassign(cur_col_coord[c].clone(), grammars.clone(), 1);
+                                    grammars.insert(cur_col_coord[c].clone(), temp[u].clone());
+                                    u += 1;
+                                }
+                                u = 0;
+                        }else{
                             let parent = next_col.parent().unwrap();
                             if let Some(Grammar {
                                 kind: Kind::Grid(sub_coords),
@@ -1218,7 +1255,7 @@ impl Component for Model {
                             {
                                 new_col_coords = sub_coords.clone();
 
-                                for c in col_coords1.clone() {
+                                for c in cur_col_coord.clone() {
                                     for i in (0..new_col_coords.len()).rev() {
                                         if new_col_coords[i] == (c.row(), c.col()) {
                                             new_col_coords.remove(i);
@@ -1231,6 +1268,9 @@ impl Component for Model {
                                 }
                                 grammars.remove(&parent);
                                 grammars.remove(&next_col);
+                                for c in next_col_coord.clone() {
+                                    grammars.remove(&c);
+                                }
                                 grammars.insert(
                                     parent,
                                     Grammar {
@@ -1241,15 +1281,9 @@ impl Component for Model {
                                 );
                                 break;
                             }
-                        } else {
-                            for c in (0..col_coords1.len()).rev() {
-                                grammars.insert(col_coords1[c].clone(), temp[u].clone());
-                                u += 1;
-                            }
-                            u = 0;
                         }
 
-                        col_coords1 = col_coords2.clone();
+                        cur_col_coord = next_col_coord.clone();
                         next_col = right_coord;
                     }
                     self.get_session_mut().grammars = grammars;

--- a/src/view.rs
+++ b/src/view.rs
@@ -6,8 +6,8 @@ use stdweb::unstable::TryInto;
 use stdweb::web::{html_element::InputElement, HtmlElement, IHtmlElement};
 use yew::events::{ClickEvent, IKeyboardEvent, IMouseEvent, KeyPressEvent};
 use yew::prelude::*;
-use yew::virtual_dom::vlist::VList;
 use yew::services::reader::File;
+use yew::virtual_dom::vlist::VList;
 use yew::{html, ChangeData, Html, InputData};
 
 use crate::coordinate::Coordinate;
@@ -840,23 +840,58 @@ pub fn view_grid_grammar(m: &Model, coord: &Coordinate, sub_coords: Vec<Coordina
 
 pub fn view_context_menu(m: &Model) -> Html {
     let default_options = vec![
-        ("Insert Row", m.link.callback(|_| Action::InsertRow), true, 1),
-        ("Insert Col", m.link.callback(|_| Action::InsertCol), true, 1),
-        ("Delete Row", m.link.callback(|_| Action::DeleteRow), true, 1),
-        ("Delete Col", m.link.callback(|_| Action::DeleteCol), true, 1),
-
-        ("----------",  m.link.callback(|_| Action::HideContextMenu), true, 0),
-
+        (
+            "Insert Row",
+            m.link.callback(|_| Action::InsertRow),
+            true,
+            1,
+        ),
+        (
+            "Insert Col",
+            m.link.callback(|_| Action::InsertCol),
+            true,
+            1,
+        ),
+        (
+            "Delete Row",
+            m.link.callback(|_| Action::DeleteRow),
+            true,
+            1,
+        ),
+        (
+            "Delete Col",
+            m.link.callback(|_| Action::DeleteCol),
+            true,
+            1,
+        ),
+        (
+            "----------",
+            m.link.callback(|_| Action::HideContextMenu),
+            true,
+            0,
+        ),
         ("Zoom In (+)", m.link.callback(|_| Action::ZoomIn), true, 2),
-        ("Zoom Reset", m.link.callback(|_| Action::ZoomReset), true, 2),
-        ("Zoom Out (-)", m.link.callback(|_| Action::ZoomOut), true, 2),
-
-        ("----------",  m.link.callback(|_| Action::HideContextMenu), true, 0),
-
+        (
+            "Zoom Reset",
+            m.link.callback(|_| Action::ZoomReset),
+            true,
+            2,
+        ),
+        (
+            "Zoom Out (-)",
+            m.link.callback(|_| Action::ZoomOut),
+            true,
+            2,
+        ),
+        (
+            "----------",
+            m.link.callback(|_| Action::HideContextMenu),
+            true,
+            0,
+        ),
         ("Save", m.link.callback(|_| Action::SaveSession()), true, 3),
         ("Reset", m.link.callback(|_| Action::Recreate), true, 3),
         ("Merge", m.link.callback(|_| Action::MergeCells()), false, 3),
-
     ];
     /*option Name and action are what their name means
     option_param represents the default or conditionnal render of an option
@@ -865,7 +900,7 @@ pub fn view_context_menu(m: &Model) -> Html {
     */
     let option_nodes = {
         let mut v = VList::new();
-        
+
         for (option_name, option_action, option_param, option_layer) in default_options {
             let mut should_render = true;
 


### PR DESCRIPTION
- Delete Row didn't work for nested grids. 

Now a new function called Reassign has been added to recursively reassign every level of nested grids in case of delete. _**(still needs work for column and styling)**_

The problem : 
![Delete](https://user-images.githubusercontent.com/46965213/80982931-f7ae7480-8df9-11ea-9f74-003ce8a4958c.gif)

Solved:
![deleteRow](https://user-images.githubusercontent.com/46965213/80985364-1f530c00-8dfd-11ea-9026-08028793d3a4.gif)


- AddnestedGrid didn't work for anything different from the Root grid, because the next line replaced the root grid or the selected cell's parents' grid with the selected cell's grid.
![carbon](https://user-images.githubusercontent.com/46965213/80982866-e2394a80-8df9-11ea-92a3-2cc1616593e8.png)
