### PR TITLE
minimal implementation of Python integration

### DIFF
--- a/src/codemirror.rs
+++ b/src/codemirror.rs
@@ -1,0 +1,78 @@
+use crate::coordinate::*;
+use stdweb::web::{html_element::TextAreaElement, IHtmlElement};
+use yew::prelude::*;
+
+pub struct CodeMirror {
+    code: String,
+    mode: String,
+    coordinate: Coordinate,
+    link: ComponentLink<Self>,
+    node_ref: NodeRef,
+}
+
+pub enum Msg {
+    UpdateCode(String),
+}
+
+#[derive(Clone, PartialEq, Properties)]
+pub struct Props {
+    pub content: String,
+    pub mode: String,
+    pub coordinate: Coordinate,
+}
+
+impl Component for CodeMirror {
+    type Message = Msg;
+    type Properties = Props;
+
+    fn create(props: Self::Properties, link: ComponentLink<Self>) -> Self {
+        CodeMirror {
+            code: props.content,
+            mode: props.mode,
+            coordinate: props.coordinate,
+            link,
+            node_ref: NodeRef::default(),
+        }
+    }
+
+    fn update(&mut self, msg: Self::Message) -> ShouldRender {
+        match msg {
+            Msg::UpdateCode(code) => {
+                self.code = code;
+                true
+            }
+        }
+    }
+
+    fn mounted(&mut self) -> ShouldRender {
+        /// TODO: this code runs the codemirror instantiation, but it doesn't work too well.
+        /// leave it disabled for now, so we'll just have a regular textarea in it's place
+        // if let Some(input) = self.node_ref.cast::<TextAreaElement>() {
+        //     input.focus();
+        // }
+        // let element_id = format! {"codemirror-{}", self.coordinate.to_string()};
+        // js! {
+        //     let codeMirrorInstance = CodeMirror.fromTextArea(document.getElementById(@{element_id}), {
+        //         lineNumbers: true,
+        //         mode: "python"
+        //     });
+        //     codeMirrorInstance.setValue(@{&self.code});
+        //     setTimeout(function() {
+        //         codeMirrorInstance.refresh();
+        //         console.log("codemirror instance setup finished!");
+        //     },1);
+        // }
+        false
+    }
+
+    fn view(&self) -> Html {
+        html! {
+            <textarea
+                value={self.code.clone()}
+                ref={self.node_ref.clone()}
+                id=format!{"codemirror-{}", self.coordinate.to_string()}
+                oninput=self.link.callback(move |e: InputData| Msg::UpdateCode(e.value))>
+            </textarea>
+        }
+    }
+}

--- a/src/coordinate.rs
+++ b/src/coordinate.rs
@@ -2,6 +2,7 @@ use pest::Parser;
 use serde::{Deserialize, Serialize};
 use std::char::from_u32;
 use std::num::NonZeroU32;
+use std::ops::Deref;
 use std::option::Option;
 use std::panic;
 

--- a/src/coordinate.rs
+++ b/src/coordinate.rs
@@ -25,7 +25,6 @@ impl Coordinate {
     pub fn child_of(parent: &Self, child_coord: (NonZeroU32, NonZeroU32)) -> Coordinate {
         let mut new_row_col = parent.clone().row_cols;
         new_row_col.push(child_coord);
-        info!("pareb = {:?}, child_coord = {:?}", parent, child_coord);
 
         Coordinate {
             row_cols: new_row_col,

--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -60,6 +60,8 @@ pub enum Kind {
         /* definition coord */ Coordinate,
         /* rule names and coordinates */ Vec<(String, Coordinate)>,
     ),
+
+    Editor(/* content */ String),
 }
 js_serializable!(Kind);
 js_deserializable!(Kind);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,7 @@ pub mod session;
 pub mod style;
 pub mod util;
 pub mod view;
+pub mod codemirror;
 
 use crate::model::Model;
 

--- a/src/model.rs
+++ b/src/model.rs
@@ -4,11 +4,12 @@ use std::collections::{HashMap, HashSet};
 extern crate csv;
 use csv::Error;
 
+use std::iter::IntoIterator;
 use std::num::NonZeroU32;
 use std::ops::Deref;
 use std::option::Option;
 use stdweb::traits::IEvent;
-use stdweb::unstable::TryInto;
+use stdweb::unstable::{TryFrom, TryInto};
 use stdweb::web::{document, IElement, INode, IParentNode};
 use wasm_bindgen::JsValue;
 use yew::events::{KeyDownEvent, KeyPressEvent, KeyUpEvent};
@@ -217,8 +218,8 @@ pub enum Action {
     LoadCSVFile(FileData, Coordinate),
 
     RunPython(
-        String, /* TODO: pass in sheet as well */
-        Coordinate /* output_coord */
+        String,     /* TODO: pass in sheet as well */
+        Coordinate, /* output_coord */
     ),
 }
 
@@ -371,17 +372,16 @@ impl Component for Model {
                             [
                                 g!(Grammar::input("", "A3")),
                                 g!(Grammar::input("", "B3")),
-                                g!(Grammar::input("", "C3"))
-                                // grid![
-                                //     [
-                                //         g!(Grammar::input("", "C3-A1")),
-                                //         g!(Grammar::input("", "C3-B1"))
-                                //     ],
-                                //     [
-                                //         g!(Grammar::input("", "C3-A2")),
-                                //         g!(Grammar::input("", "C3-B2"))
-                                //     ]
-                                // ]
+                                g!(Grammar::input("", "C3")) // grid![
+                                                             //     [
+                                                             //         g!(Grammar::input("", "C3-A1")),
+                                                             //         g!(Grammar::input("", "C3-B1"))
+                                                             //     ],
+                                                             //     [
+                                                             //         g!(Grammar::input("", "C3-A2")),
+                                                             //         g!(Grammar::input("", "C3-B2"))
+                                                             //     ]
+                                                             // ]
                             ]
                         ],
                     );
@@ -511,7 +511,7 @@ impl Component for Model {
             Action::LoadCSVFile(file_data, coordinate) => {
                 let csv = std::str::from_utf8(&file_data.content).unwrap().to_string();
                 let mut reader = csv::Reader::from_reader(csv.as_bytes());
-                let mut grid : Vec<Vec<String>> = Vec::new();
+                let mut grid: Vec<Vec<String>> = Vec::new();
                 let headers_csv = reader.headers().unwrap();
                 let mut header_row: Vec<String> = Vec::new();
                 let len_header = headers_csv.len() as i32;
@@ -535,8 +535,11 @@ impl Component for Model {
                 let num_rows = grid.len();
                 let num_cols = grid[0].len();
 
-                self.update(Action::AddNestedGrid(coordinate.clone(), (num_rows as u32, num_cols as u32)));
-                
+                self.update(Action::AddNestedGrid(
+                    coordinate.clone(),
+                    (num_rows as u32, num_cols as u32),
+                ));
+
                 let parent = coordinate.parent().unwrap();
                 if let Some(Grammar {
                     kind: Kind::Grid(sub_coords),
@@ -552,10 +555,10 @@ impl Component for Model {
                         let grid_: &str = &grid[row_ - 1][col_ - 1];
                         grammar.remove(&c);
                         grammar.insert(c, Grammar::input("", grid_));
-                     };
-                     self.get_session_mut().grammars = grammar;
-                 }
-                 
+                    }
+                    self.get_session_mut().grammars = grammar;
+                }
+
                 true
             }
 
@@ -581,34 +584,35 @@ impl Component for Model {
                         while selection_start.parent() != common_parent {
                             selection_start = selection_start.parent().unwrap();
                         }
-                    
                     }
-                 // find the min of row,col and max of row,col in selected region 
-                 // which may contain a span coord that has smaller or larger row,col
+                    // find the min of row,col and max of row,col in selected region
+                    // which may contain a span coord that has smaller or larger row,col
                     let (mut start_row, mut start_col) = selection_start.clone().row_col();
                     let (mut end_row, mut end_col) = selection_end.clone().unwrap().row_col();
                     if start_row > end_row {
                         let tmp = start_row.clone();
                         start_row = end_row;
                         end_row = tmp;
-                    } 
+                    }
                     if start_col > end_col {
                         let tmp = start_col.clone();
                         start_col = end_col;
                         end_col = tmp;
-                    }            
+                    }
                     let depth_check = selection_start.row_cols.len().clone();
                     let ref_grammas = self.get_session().grammars.clone();
                     let mut check = false;
                     while !check {
                         check = true;
                         let row_range = start_row.get()..=end_row.get();
-                        let col_range = start_col.get()..=end_col.get(); 
+                        let col_range = start_col.get()..=end_col.get();
                         for (coord, grammar) in ref_grammas.iter() {
                             let (coord_row, coord_col) = coord.clone().row_col();
                             let coord_depth = coord.clone().row_cols.len();
                             if row_range.contains(&coord_row.get())
-                                && col_range.contains(&coord_col.get()) && (coord_depth == depth_check) {
+                                && col_range.contains(&coord_col.get())
+                                && (coord_depth == depth_check)
+                            {
                                 let col_span = grammar.clone().style.col_span;
                                 let row_span = grammar.clone().style.row_span;
                                 if col_span.0 != 0 && col_span.1 != 0 {
@@ -634,7 +638,7 @@ impl Component for Model {
                             }
                         }
                     }
-                                     
+
                     selection_start.row_cols[depth_check - 1] = (start_row, start_col);
                     selection_end.as_mut().unwrap().row_cols[depth_check - 1] = (end_row, end_col);
                     self.first_select_cell = Some(selection_start.clone());
@@ -646,40 +650,41 @@ impl Component for Model {
             Action::RangeDelete() => {
                 let (first_row, first_col) = self.first_select_cell.clone().unwrap().row_col();
                 let (last_row, last_col) = self.last_select_cell.clone().unwrap().row_col();
-                
+
                 let row_range = first_row.get()..=last_row.get();
-                let col_range = first_col.get()..=last_col.get(); 
+                let col_range = first_col.get()..=last_col.get();
 
                 let parent_check = self.last_select_cell.clone().unwrap().parent();
-                let depth_check = self.last_select_cell.clone().unwrap().row_cols.len();  
-                              
+                let depth_check = self.last_select_cell.clone().unwrap().row_cols.len();
+
                 let mut ref_grammars = self.get_session_mut().grammars.clone();
-                for (coord, grammar) in ref_grammars.clone().iter_mut() {              
-                        if row_range.contains(&coord.row().get()) && col_range.contains(&coord.col().get()) && coord.parent() == parent_check                    
-                        {                                                       
-                            let get_kind = grammar.kind.clone();
-                            match get_kind {
-                                Kind::Input(value) => {
-                                    grammar.kind =  Kind::Input("".to_string());                                 
-                                    self.get_session_mut()
+                for (coord, grammar) in ref_grammars.clone().iter_mut() {
+                    if row_range.contains(&coord.row().get())
+                        && col_range.contains(&coord.col().get())
+                        && coord.parent() == parent_check
+                    {
+                        let get_kind = grammar.kind.clone();
+                        match get_kind {
+                            Kind::Input(value) => {
+                                grammar.kind = Kind::Input("".to_string());
+                                self.get_session_mut()
                                     .grammars
                                     .insert(coord.clone(), grammar.clone());
-                                }
-                                Kind::Grid(sub_coords) => {                              
-                                    for (c, g) in ref_grammars.clone().iter_mut() {
-                                        if c.parent().is_some() && c.parent().unwrap() == coord.clone() {                          
-                                            g.kind =  Kind::Input("".to_string());                                 
-                                            self.get_session_mut()
+                            }
+                            Kind::Grid(sub_coords) => {
+                                for (c, g) in ref_grammars.clone().iter_mut() {
+                                    if c.parent().is_some() && c.parent().unwrap() == coord.clone()
+                                    {
+                                        g.kind = Kind::Input("".to_string());
+                                        self.get_session_mut()
                                             .grammars
                                             .insert(c.clone(), g.clone());
-                                        }
                                     }
                                 }
-                                _=> continue,
-                            }                                                                                                      
-                            
+                            }
+                            _ => continue,
                         }
-                                         
+                    }
                 }
                 true
             }
@@ -688,61 +693,62 @@ impl Component for Model {
                 if self.first_select_cell.is_none() || self.last_select_cell.is_none() {
                     info!("Expect for select of two coord");
                     return false;
-                }           
+                }
                 let (first_row, first_col) = self.first_select_cell.clone().unwrap().row_col();
                 let (last_row, last_col) = self.last_select_cell.clone().unwrap().row_col();
-                
+
                 let depth_check = self.last_select_cell.clone().unwrap().row_cols.len();
                 let parent_check = self.last_select_cell.clone().unwrap().parent();
 
                 let row_range = first_row.get()..=last_row.get();
-                let col_range = first_col.get()..=last_col.get(); 
-                
+                let col_range = first_col.get()..=last_col.get();
+
                 let mut merge_height = 0.00;
                 let mut merge_width = 0.00;
                 let mut max_coord = Coordinate::default();
                 let mut max_grammar = Grammar::default();
                 let mut ref_grammas = self.get_session_mut().grammars.clone();
                 for (coord, grammar) in ref_grammas.iter_mut() {
-                    if  coord.to_string().contains("root-") {
-                        if row_range.contains(&coord.row().get()) && col_range.contains(&coord.col().get()) && coord.parent() == parent_check                    
-                        {                                                  
+                    if coord.to_string().contains("root-") {
+                        if row_range.contains(&coord.row().get())
+                            && col_range.contains(&coord.col().get())
+                            && coord.parent() == parent_check
+                        {
                             let coord_style = grammar.style.clone();
-                            if coord_style.display != false  { 
-                                if coord.row().get() == last_row.get() {  
+                            if coord_style.display != false {
+                                if coord.row().get() == last_row.get() {
                                     merge_width = merge_width + coord_style.width;
-                                
-                                } 
+                                }
                                 if coord.col().get() == last_col.get() {
                                     merge_height = merge_height + coord_style.height;
                                 }
-                                    if coord.row().get() == last_row.get()
+                                if coord.row().get() == last_row.get()
                                     && (coord.col().get() == last_col.get())
-                                {          
+                                {
                                     max_coord = coord.clone();
                                     max_grammar = grammar.clone();
                                 } else {
                                     grammar.style.display = false;
-                                }                                            
+                                }
                             }
-                            grammar.kind =  Kind::Input("".to_string());                   
+                            grammar.kind = Kind::Input("".to_string());
                             grammar.style.col_span.0 = first_col.get();
                             grammar.style.col_span.1 = last_col.get();
                             grammar.style.row_span.0 = first_row.get();
-                            grammar.style.row_span.1 = last_row.get();                    
+                            grammar.style.row_span.1 = last_row.get();
                             self.get_session_mut()
                                 .grammars
                                 .insert(coord.clone(), grammar.clone());
                         }
-                    }                            
+                    }
                 }
-                max_grammar.kind =  Kind::Input("".to_string());
+                max_grammar.kind = Kind::Input("".to_string());
                 max_grammar.style.width = merge_width;
                 max_grammar.style.height = merge_height;
                 max_grammar.style.col_span.0 = first_col.get();
                 max_grammar.style.col_span.1 = last_col.get();
                 max_grammar.style.row_span.0 = first_row.get();
-                max_grammar.style.row_span.1 = last_row.get();             
+                max_grammar.style.row_span.1 = last_row.get();
                 self.get_session_mut()
                     .grammars
                     .insert(max_coord.clone(), max_grammar.clone());
@@ -971,7 +977,7 @@ impl Component for Model {
                 if let Kind::Grid(sub_coords) = grammar.clone().kind {
                     // set active cell to first cell inside the new nested grammar
                     self.active_cell = sub_coords.first().map(|c| Coordinate::child_of(&coord, *c));
-                               
+
                     let current_width = current_grammar.style.width;
                     let current_height = current_grammar.style.height;
 
@@ -1010,28 +1016,27 @@ impl Component for Model {
                         }
                     }
                 }
-               
+
                 if let Some(parent) = Coordinate::parent(&coord)
                     .and_then(|p| self.get_session_mut().grammars.get_mut(&p))
                 {
                     parent.kind = grammar.clone().kind; // make sure the parent gets set to Kind::Grid
-                } 
-                 
+                }
+
                 if current_grammar.style.row_span.0 != 0 || current_grammar.style.col_span.0 != 0 {
                     grammar.style.row_span = current_grammar.style.row_span.clone();
                     grammar.style.col_span = current_grammar.style.col_span.clone();
                 }
                 self.get_session_mut()
                     .grammars
-                    .insert(coord.clone(), grammar.clone());           
+                    .insert(coord.clone(), grammar.clone());
                 resize(
                     self,
                     coord.clone(),
                     (rows as f64) * (/* default row height */tmp_heigth),
                     (cols as f64) * (/* default col width */tmp_width),
                 );
-                
-               
+
                 true
             }
 
@@ -1314,7 +1319,7 @@ impl Component for Model {
                 }
                 true
             }
-            
+
             // Action::Recreate => {
             //     self.get_session_mut().grammars = hashmap! {
             //         coord!("root")    => self.get_session_mut().root.clone(),
@@ -1353,10 +1358,9 @@ impl Component for Model {
             //     };
             //     true
             // }
-
             Action::Recreate => {
                 self.get_session_mut().grammars = {
-                    info!{"~rec is being fired"}
+                    info! {"~rec is being fired"}
                     let mut map = HashMap::new();
                     build_grammar_map(
                         &mut map,
@@ -1427,8 +1431,6 @@ impl Component for Model {
                 };
                 true
             }
-            
-            
 
             Action::Resize(msg) => {
                 match msg {
@@ -1588,18 +1590,39 @@ impl Component for Model {
                     "codemirror-{}",
                     self.active_cell.clone().map(|c| c.to_string()).unwrap_or(String::new()),
                 };
-                // TODO: find a way to return data after execution by Pyodide
-                let return_value : String = js! {
+                // TODO: later, find a way to parse the grammar values into valid python
+                // expressions if that's what the grammars represent.
+                // We could also filter the entire map on that basis, no need to include
+                // irrelevant grammars
+                let string_map: HashMap<String, String> = self
+                    .get_session()
+                    .grammars
+                    .clone()
+                    .into_iter()
+                    .map(|(k, v)| (k.to_string(), serde_json::to_string(&v).unwrap()))
+                    .collect();
+                let grammars = stdweb::Object::try_from(string_map).expect(
+                    "[Action:RunPython] Grammar Map can be serialized into Javascript Object",
+                );
+                let return_value: String = js! {
                     let editorEl = document.getElementById(@{editor_id.clone()});
                     let code = editorEl.value;
+                    pyodide.globals.grammars = @{grammars};
                     return pyodide.runPython(code);
-                }.try_into().unwrap();
-                if let Some(g @ Grammar {
-                            kind: Kind::Input(_),
-                            ..
-                        }) = self.get_session_mut().grammars.get_mut(&output_coord) {
-                            g.kind = Kind::Input(return_value);
-                    }
+                }
+                .try_into()
+                .unwrap();
+                if let Some(
+                    g
+                    @
+                    Grammar {
+                        kind: Kind::Input(_),
+                        ..
+                    },
+                ) = self.get_session_mut().grammars.get_mut(&output_coord)
+                {
+                    g.kind = Kind::Input(return_value);
+                }
 
                 false
             }

--- a/src/session.rs
+++ b/src/session.rs
@@ -133,6 +133,11 @@ impl Serialize for Kind {
                 sv.serialize_field("rules", rules)?;
                 sv.end()
             }
+            Kind::Editor(s) => {
+                let mut sv = serializer.serialize_struct_variant("Kind", 0, "Editor", 1)?;
+                sv.serialize_field("content", s)?;
+                sv.end()
+            }
         }
     }
 }

--- a/src/view.rs
+++ b/src/view.rs
@@ -12,6 +12,7 @@ use yew::services::reader::File;
 use yew::virtual_dom::vlist::VList;
 use yew::{html, ChangeData, Html, InputData};
 
+use crate::codemirror::CodeMirror;
 use crate::coordinate::Coordinate;
 use crate::grammar::{Grammar, Interactive, Kind, Lookup};
 use crate::model::{Action, CursorType, Model, ResizeMsg, SelectMsg, SideMenu};
@@ -346,6 +347,9 @@ pub fn view_menu_bar(m: &Model) -> Html {
             <button id="DeleteCol" class="menu-bar-button" onclick=m.link.callback(|_| Action::DeleteCol)>
                 { "Delete Column" }
             </button>
+            <button id="NewEditor" class="menu-bar-button" onclick=m.link.callback(|_| Action::NewEditor)>
+                { "New Editor" }
+            </button>
             //<>
                 { add_definition_button }
             //</>
@@ -471,9 +475,17 @@ pub fn view_grammar(m: &Model, coord: Coordinate) -> Html {
             Kind::Defn(name, defn_coord, sub_grammars) => {
                 view_defn_grammar(m, &coord, &defn_coord, name, sub_grammars)
             }
+            Kind::Editor(content) => view_editor_grammar(m, &coord, content),
         }
     } else {
         html! { <></> }
+    }
+}
+
+pub fn view_editor_grammar(m: &Model, coord: &Coordinate, content: String) -> Html {
+    html! {
+        <CodeMirror content={content} coordinate={coord.clone()}>
+        </CodeMirror>
     }
 }
 

--- a/src/view.rs
+++ b/src/view.rs
@@ -1,4 +1,5 @@
 #![recursion_limit = "1024"]
+use pest::Parser;
 use std::num::NonZeroU32;
 use std::ops::Deref;
 use stdweb::traits::IEvent;
@@ -18,6 +19,11 @@ use crate::grammar::{Grammar, Interactive, Kind, Lookup};
 use crate::model::{Action, CursorType, Model, ResizeMsg, SelectMsg, SideMenu};
 use crate::style::get_style;
 use crate::util::non_zero_u32_tuple;
+use crate::{coord};
+
+#[derive(Parser)]
+#[grammar = "coordinate.pest"]
+pub struct CoordinateParser;
 
 pub fn view_side_nav(m: &Model) -> Html {
     let mut side_menu_nodes = VList::new();
@@ -349,6 +355,9 @@ pub fn view_menu_bar(m: &Model) -> Html {
             </button>
             <button id="NewEditor" class="menu-bar-button" onclick=m.link.callback(|_| Action::NewEditor)>
                 { "New Editor" }
+            </button>
+            <button id="RunPython" class="menu-bar-button" onclick=m.link.callback(|_| Action::RunPython("import sys\nsys.version\nprint(1+2)".to_string(), coord!("root-A1")))>
+                { "Run Python" }
             </button>
             //<>
                 { add_definition_button }

--- a/static/index.html
+++ b/static/index.html
@@ -8,12 +8,13 @@
   <body>
     <script src="app.js"></script>
 
+    <!--  
+      <script src="codemirror/lib/codemirror.js"></script>
+      <link rel="stylesheet" href="codemirror/lib/codemirror.css">
+      <script src="codemirror/mode/python/python.js"></script>
+    -->
 
-    <script src="codemirror/lib/codemirror.js"></script>
-    <link rel="stylesheet" href="codemirror/lib/codemirror.css">
-    <script src="codemirror/mode/python/python.js"></script>
-
-    <script src="pyodide/pyodide.js"></script>
+    <script src="https://pyodide-cdn2.iodide.io/v0.15.0/full/pyodide.js"></script>
 
   </body>
 </html>

--- a/static/index.html
+++ b/static/index.html
@@ -7,5 +7,13 @@
   </head>
   <body>
     <script src="app.js"></script>
+
+
+    <script src="codemirror/lib/codemirror.js"></script>
+    <link rel="stylesheet" href="codemirror/lib/codemirror.css">
+    <script src="codemirror/mode/python/python.js"></script>
+
+    <script src="pyodide/pyodide.js"></script>
+
   </body>
 </html>


### PR DESCRIPTION
This commit implements both the integration of "Pyodide" driver and a small text editing interface. Our tool is supposed to support structured editing in python but that work is still in progress in #23 (korede/nested_defn). So to illustrate the basic functionality, we have a simple textarea where you can write in Python code and hit the "Run Python" button in the title bar to print it out.

The constraints to the current approach are: We can only print out values that are Strings, and I haven't setup a way to pass out own values into the environment. That's next on the TODO for this, then I'll make a more complicated data science example that utilizes a CSV file that's been dropped into the environment.

I also implemented a new "CodeMirror" component that's also WIP. I decided we might as well embed a traditional text editor into our environment to give us the ability to easily interact with code.

Gif of using data from sheet:
![Screen-Recording-2020-05-15-at-3](https://user-images.githubusercontent.com/16245199/82089686-1518f380-96c2-11ea-9b0d-d5cc6efaedd5.gif)
